### PR TITLE
Rescue using full capacity of USB drive + sync.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# IDEA project files
+.idea
+*.iml
+
+# Build files
+target

--- a/bin/emrk-factory-reset
+++ b/bin/emrk-factory-reset
@@ -50,4 +50,9 @@ fi
 
 rm -f $ROOT_MNT_DIR/$CONFIG
 
+## Waiting for disk sync.
+echo "Waiting for disk sync"
+sync
+
+# All done - let's reboot
 echo "Factory reset finished, you may reboot the router"

--- a/bin/emrk-reinstall
+++ b/bin/emrk-reinstall
@@ -83,14 +83,16 @@ echo "Formatting boot partition"
 mkfs.vfat $BOOT
 
 # Root
-echo "Creating root partition"
 echo "Use full USB Drive capacity?"
 $YESNO
+
 if [ $? == 0 ]; then
     # Use full capacity
+    echo "Creating root partition - Full capacity"
     $PARTED --script $DEV mkpart primary ext3 150MB -1s
 else
     # Use only 1900MB for ROOT partion
+    echo "Creating root partition - 2GB default"
     $PARTED --script $DEV mkpart primary ext3 150MB 1900MB
 fi
 echo "Formatting root partition"

--- a/bin/emrk-reinstall
+++ b/bin/emrk-reinstall
@@ -84,7 +84,15 @@ mkfs.vfat $BOOT
 
 # Root
 echo "Creating root partition"
-$PARTED --script $DEV mkpart primary ext3 150MB 1900MB
+echo "Use full USB Drive capacity?"
+$YESNO
+if [ $? == 0 ]; then
+    # Use full capacity
+    $PARTED --script $DEV mkpart primary ext3 150MB -1s
+else
+    # Use only 1900MB for ROOT partion
+    $PARTED --script $DEV mkpart primary ext3 150MB 1900MB
+fi
 echo "Formatting root partition"
 mkfs.ext3 -q $ROOT
 

--- a/bin/emrk-reinstall
+++ b/bin/emrk-reinstall
@@ -157,5 +157,10 @@ mkdir $ROOT_MNT_DIR/$W_DIR
 echo "Cleaning up"
 rm -rf $TMP_DIR
 
+## Waiting for disk sync.
+echo "Waiting for disk sync"
+sync
+
+# All done - let's reboot
 echo "Installation finished"
 echo "Please reboot your router"

--- a/bin/emrk-reinstall
+++ b/bin/emrk-reinstall
@@ -88,11 +88,12 @@ $YESNO
 
 if [ $? == 0 ]; then
     # Use full capacity
-    echo "Creating root partition - Full capacity"
-    $PARTED --script $DEV mkpart primary ext3 150MB -1s
+    echo "Creating root partition - using full capacity"
+    $PARTED --script $DEV mkpart primary ext3 150MB 100%
+    echo "Depending on the size of your drive, this step might take some time"
 else
     # Use only 1900MB for ROOT partion
-    echo "Creating root partition - 2GB default"
+    echo "Creating root partition - using 2GB default"
     $PARTED --script $DEV mkpart primary ext3 150MB 1900MB
 fi
 echo "Formatting root partition"

--- a/bin/emrk-reinstall
+++ b/bin/emrk-reinstall
@@ -97,7 +97,7 @@ echo "Formatting root partition"
 mkfs.ext3 -q $ROOT
 
 ## Mount partitions
-echo "Mounting boot parition"
+echo "Mounting boot partition"
 mount -t vfat $BOOT $BOOT_MNT_DIR
 
 echo "Mounting root partition"

--- a/bin/emrk-remove-user-data
+++ b/bin/emrk-remove-user-data
@@ -48,3 +48,10 @@ fi
 find $ROOT_MNT_DIR -name w* -print  | xargs /bin/rm -rf
 
 mkdir $ROOT_MNT_DIR/w
+
+## Waiting for disk sync.
+echo "Waiting for disk sync"
+sync
+
+# All done - let's reboot
+echo "User data removed, you may reboot the router"


### PR DESCRIPTION
Daniil,
This is a small update to the ermk-reinstall script that asks the user if they want to use the full capacity of the USB drive. If the user answers no - then the previous default values are used.

Added a sync command at the request of forums users.
