### PR TITLE
Make bin/emrk-reinstall work on other systems

### DIFF
--- a/bin/emrk-reinstall
+++ b/bin/emrk-reinstall
@@ -55,7 +55,7 @@ echo "it will be irrecoverably destroyed!"
 echo "Do you want to continue?"
 $YESNO
 
-if [ $? == 1 ]; then
+if [ $? -eq 1 ]; then
     exit 0
 fi
 
@@ -69,6 +69,10 @@ if mount | grep $ROOT > /dev/null; then
     echo "Unmounting root partition"
     umount $ROOT
 fi
+
+# Create the mount points if they don't exist
+mkdir -p $BOOT_MNT_DIR
+mkdir -p $ROOT_MNT_DIR
 
 ## Repartition
 
@@ -86,7 +90,7 @@ mkfs.vfat $BOOT
 echo "Use full USB Drive capacity?"
 $YESNO
 
-if [ $? == 0 ]; then
+if [ $? -eq 0 ]; then
     # Use full capacity
     echo "Creating root partition - using full capacity"
     $PARTED --script $DEV mkpart primary ext3 150MB 100%
@@ -122,7 +126,7 @@ done
 
 # Unpack image
 echo "Unpacking EdgeOS release image"
-tar xf $TMP_DIR/edgeos.tar -C $TMP_DIR
+tar xf $TAR_PATH -C $TMP_DIR
 
 # The kernel
 echo "Verifying EdgeOS kernel"

--- a/bin/emrk-reinstall
+++ b/bin/emrk-reinstall
@@ -111,11 +111,12 @@ echo "Mounting root partition"
 mount -t ext3 $ROOT $ROOT_MNT_DIR
 
 ## Download image
-mkdir $ROOT_MNT_DIR/tmp
-while true; do
+mkdir -p $TMP_DIR
+while [ -z "$TAR_PATH" ]; do
     read -p "Enter EdgeOS image url: " URL
     curl -o $ROOT_MNT_DIR/tmp/edgeos.tar $URL
     if [ $? == 0 ]; then
+        TAR_PATH=$TMP_DIR/edgeos.tar
         break
     else
         echo "Could not download EdgeOS image, try again!"

--- a/bin/emrk-reinstall
+++ b/bin/emrk-reinstall
@@ -46,14 +46,14 @@ SQUASHFS_MD5=squashfs.img.md5
 VERSION=version
 
 PARTED=/sbin/parted
-YESNO=/bin/yesno
+YESNO="$(dirname "$0")"/yesno
 
 # Scary disclaimer
 echo "WARNING: This script will reinstall EdgeOS from scratch"
 echo "If you have any usable data on your router storage,"
 echo "it will be irrecoverably destroyed!"
 echo "Do you want to continue?"
-$YESNO
+"$YESNO"
 
 if [ $? -eq 1 ]; then
     exit 0
@@ -88,7 +88,7 @@ mkfs.vfat $BOOT
 
 # Root
 echo "Use full USB Drive capacity?"
-$YESNO
+"$YESNO"
 
 if [ $? -eq 0 ]; then
     # Use full capacity

--- a/bin/emrk-reinstall
+++ b/bin/emrk-reinstall
@@ -23,13 +23,14 @@
 # It's time to reinstall EdgeOS!
 # EdgeOS won't reinstall itself!
 
-DEV=/dev/sda
-BOOT=/dev/sda1
-ROOT=/dev/sda2
+DEV=$EMRK_DEV || /dev/sda
+BOOT=${DEV}1
+ROOT=${DEV}2
 BOOT_MNT_DIR=/mnt/boot
 ROOT_MNT_DIR=/mnt/root
 TMP_DIR=$ROOT_MNT_DIR/tmp
 W_DIR=w
+TAR_PATH=$EMRK_TAR_PATH
 
 # Release tarball file names
 KERNEL_ORIG=vmlinux.tmp

--- a/bin/yesno
+++ b/bin/yesno
@@ -46,7 +46,7 @@ else
 fi
 
 while true; do
-    read -p "$prompt" || exit 1
+    read -p "$prompt" REPLY || exit 1
     if [ -z "$REPLY" -a ! -z "$default" ];then
         REPLY=$default
     fi


### PR DESCRIPTION
I was recovering my ERLite-3 recently and didn't have a serial console handy. I tweaked these scripts so that you can run `bin/emrk-reinstall` on a normal Linux system! It worked fine once I installed `parted` and `dosfstools` on my Debian Buster system.

#### Usage
`EMRK_DEV` points to `/dev/sda` by default (as before) but can point to whatever your USB key is (mine was `/dev/sdb`).

The script also still prompts for a URL by default, but it'll use the tar file pointed to be `EMRK_TAR_PATH` if it's specified.